### PR TITLE
suppress type error in createGlobalForm

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -71,6 +71,7 @@ const App = ({ Component, pageProps }) => {
             }}
             formifyCallback={({ formConfig, createForm, createGlobalForm }) => {
               if (formConfig.id === "getGlobalDocument") {
+                //@ts-ignore this function is typed incorrectly
                 return createGlobalForm(formConfig, { layout: "fullscreen" });
               }
 


### PR DESCRIPTION
tinacms is exposing an incorrect type signature here, so we just need to ignore it for now